### PR TITLE
Feat: chakra ui custom theme 설정

### DIFF
--- a/apps/se-board/package.json
+++ b/apps/se-board/package.json
@@ -29,6 +29,7 @@
     "@chakra-ui/react": "^2.5.1",
     "@emotion/react": "^11.10.6",
     "@emotion/styled": "^11.10.6",
+    "@fontsource/noto-sans-kr": "^4.5.12",
     "@tanstack/react-query": "^4.26.1",
     "@tanstack/react-query-devtools": "^4.26.1",
     "@testing-library/jest-dom": "^5.16.5",

--- a/apps/se-board/src/styles/chakraTheme.ts
+++ b/apps/se-board/src/styles/chakraTheme.ts
@@ -1,15 +1,68 @@
-import { extendTheme } from "@chakra-ui/react";
+import { ComponentStyleConfig, extendTheme } from "@chakra-ui/react";
 
 import { openColors } from "./openColor";
+import { semanticColors } from "./semanticColor";
 
-export const semanticColors_1 = {
-  primary: openColors.blue[5],
-  "primary-focus": openColors.blue[7],
-  "primary-comtent": openColors.white,
-  error: openColors.red[7],
-  "error-content": openColors.white,
-} as const;
+const buttonStyle: ComponentStyleConfig = {
+  variants: {
+    primary: {
+      backgroundColor: semanticColors.primary,
+      _hover: {
+        bg: semanticColors["primary-focus"],
+        backgroundColor: semanticColors["primary-focus"],
+        _disabled: {
+          backgroundColor: semanticColors.primary,
+        },
+      },
+      _disabled: {
+        bakgroundColor: semanticColors.primary,
+      },
+    },
+    "primary-outline": {
+      border: `1px solid ${semanticColors.primary}`,
+      color: semanticColors.primary,
+      _hover: {
+        backgroundColor: semanticColors.primary,
+        color: semanticColors["primary-content"],
+      },
+    },
+    danger: {
+      backgroundColor: semanticColors.error,
+      _hover: {
+        backgroundColor: semanticColors["error-focus"],
+        _disabled: {
+          backgroundColor: semanticColors.error,
+        },
+      },
+      _disabled: {
+        bakgroundColor: semanticColors.error,
+      },
+    },
+    "danger-outline": {
+      border: `1px solid ${semanticColors.error}`,
+      color: semanticColors.error,
+      _hover: {
+        backgroundColor: semanticColors.error,
+        color: semanticColors["error-content"],
+      },
+    },
+  },
+};
 
 export const theme = extendTheme({
-  colors: { ...openColors, ...semanticColors_1 },
+  styles: {
+    global: {
+      "html, body": {
+        color: openColors.gray[7],
+      },
+    },
+  },
+  fonts: {
+    heading: `"Noto Sans KR", sans-serif`,
+    body: `"Noto Sans KR", sans-serif`,
+  },
+  colors: { ...openColors, ...semanticColors },
+  components: {
+    Button: buttonStyle,
+  },
 });

--- a/apps/se-board/src/styles/index.ts
+++ b/apps/se-board/src/styles/index.ts
@@ -1,2 +1,3 @@
 export * from "./chakraTheme";
 export * from "./openColor";
+export * from "./semanticColor";

--- a/apps/se-board/src/styles/semanticColor.ts
+++ b/apps/se-board/src/styles/semanticColor.ts
@@ -1,0 +1,10 @@
+import { openColors } from "./openColor";
+
+export const semanticColors = {
+  primary: openColors.blue[5],
+  "primary-focus": openColors.blue[7],
+  "primary-content": openColors.white,
+  error: openColors.red[7],
+  "error-focus": openColors.red[8],
+  "error-content": openColors.white,
+} as const;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -31,6 +31,7 @@ importers:
       '@craco/craco': ^7.1.0
       '@emotion/react': ^11.10.6
       '@emotion/styled': ^11.10.6
+      '@fontsource/noto-sans-kr': ^4.5.12
       '@tanstack/react-query': ^4.26.1
       '@tanstack/react-query-devtools': ^4.26.1
       '@testing-library/jest-dom': ^5.16.5
@@ -58,6 +59,7 @@ importers:
       '@chakra-ui/react': 2.5.1_j67epygnvuadckncmqi3unwoce
       '@emotion/react': 11.10.6_pmekkgnqduwlme35zpnqhenc34
       '@emotion/styled': 11.10.6_oouaibmszuch5k64ms7uxp2aia
+      '@fontsource/noto-sans-kr': 4.5.12
       '@tanstack/react-query': 4.26.1_biqbaboplfbrettd7655fr4n2y
       '@tanstack/react-query-devtools': 4.26.1_brdhmlf72zuns3lsk66phyptty
       '@testing-library/jest-dom': 5.16.5
@@ -2771,6 +2773,10 @@ packages:
   /@eslint/js/8.36.0:
     resolution: {integrity: sha512-lxJ9R5ygVm8ZWgYdUweoq5ownDlJ4upvoWmO4eLxBYHdMo+vZ/Rx0EN6MbKWDJOSUGrqJy2Gt+Dyv/VKml0fjg==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+
+  /@fontsource/noto-sans-kr/4.5.12:
+    resolution: {integrity: sha512-6LBOzXw/V4guB/nATaiUjCcPxwJNGw+ky5DK7/wsgUZvfk8etH9IlKdvjFVidpeCuMVjOdlka2+MEw4hwEHaHA==}
+    dev: false
 
   /@humanwhocodes/config-array/0.11.8:
     resolution: {integrity: sha512-UybHIJzJnR5Qc/MsD9Kr+RpO2h+/P1GhOwdiLPXK5TWk5sgTdu88bTD9UP+CKbPPh5Rni1u0GjAdYQLemG8g+g==}


### PR DESCRIPTION
## 개요

notion : https://www.notion.so/chakra-custom-theme-f790db9f59aa4cb3b924aa0a8ddab897?pvs=4
<br>
<br>

## 작업내용
- 폰트 : Noto sans KR 적용
- 텍스트 기본 컬러 : openColors.gray.7
- Button 컴포넌트 variant 4가지
  - primary
  - primary-outline
  - danger
  - danger-outline
<br>
<br>

## 참고 내용
