### PR TITLE
Feat : 헤더 네비게이션 & 라우팅

### DIFF
--- a/apps/se-board/src/App.tsx
+++ b/apps/se-board/src/App.tsx
@@ -1,3 +1,27 @@
-import * as React from "react";
+import { BrowserRouter, Route, Routes } from "react-router-dom";
 
-export const App = () => <div>hello</div>;
+import { MainLayout } from "@/components/layouts";
+
+export const App = () => (
+  <BrowserRouter>
+    <Routes>
+      <Route path="" element={<MainLayout />}>
+        <Route path="" element={<div>메인</div>} />
+        <Route path="notice" element={<div>공지사항</div>} />
+        <Route path="notice/write" element={<div>공지 글쓰기</div>} />
+        <Route path="free-board" element={<div>자유게시판</div>} />
+        <Route path="free-board/write" element={<div>자유게시판 글쓰기</div>} />
+        <Route path="archive" element={<div>아카이브</div>} />
+        <Route path="archive/write" element={<div>아카이브 글쓰기</div>} />
+        <Route path="consulting" element={<div>지도교수 상담 신청</div>} />
+        <Route path="recruitment" element={<div>팀모집</div>} />
+        <Route
+          path="projectroom-reservation"
+          element={<div>프로젝트실 예약</div>}
+        />
+        <Route path="server-rental" element={<div>서버 대여</div>} />
+      </Route>
+      <Route />
+    </Routes>
+  </BrowserRouter>
+);

--- a/apps/se-board/src/assets/images/se_logo.svg
+++ b/apps/se-board/src/assets/images/se_logo.svg
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 27.3.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="레이어_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px"
+	 y="0px" width="current" height="current" viewBox="0 0 300 300" style="enable-background:new 0 0 300 300;" xml:space="preserve">
+<g>
+	<path fill="none" d="M78,266c-24.3,0-44-19.7-44-44V78c0-24.3,19.7-44,44-44h144c24.3,0,44,19.7,44,44v144c0,24.3-19.7,44-44,44H78
+		z"/>
+	<path fill="current" d="M222,40c21,0,38,17,38,38v144c0,21-17,38-38,38H78c-21,0-38-17-38-38V78c0-21,17-38,38-38H222 M222,28H78
+		c-27.6,0-50,22.4-50,50v144c0,27.6,22.4,50,50,50h144c27.6,0,50-22.4,50-50V78C272,50.4,249.6,28,222,28L222,28z"/>
+</g>
+<g>
+	<g>
+		<path fill="current" d="M112.5,130.3c17.3,0,30.2,13.8,30.2,32.9c0,18-11.6,31.6-28.6,31.6H66.7v-19.3h41.9c8.3,0,15.1-3.9,15.1-12.3
+			c0-7.9-6-12.6-13.7-12.6H97.7c-20.8,0-34.3-8.8-34.3-30.4c0-15.4,10.7-29.3,27.1-29.3h43v20.3H98.4c-7.9,0-14.3,1.3-14.3,10
+			c0,5.1,3.7,9.2,9.6,9.2H112.5z"/>
+	</g>
+	<g>
+		<path fill="current" d="M182,177.2h51.8v17.6h-71.5V90.9h71.5v17.6H182v25.7h51.8v17.3H182V177.2z"/>
+	</g>
+</g>
+</svg>

--- a/apps/se-board/src/components/HeaderNavigation.tsx
+++ b/apps/se-board/src/components/HeaderNavigation.tsx
@@ -48,11 +48,11 @@ export const DesktopHeaderNavigation = () => {
         w="full"
         align="center"
         justify="space-between"
-        px="16px"
+        px="1rem"
       >
-        <Logo size="56px" />
+        <Logo size="3.5rem" />
         <Box as="nav">
-          <Wrap spacingX="32px" spacingY="0px">
+          <Wrap spacingX="2rem" spacingY="0px">
             {DESKTOP_NAV_ITEMS.map((item) => (
               <DesktopNav key={item.name} {...item} />
             ))}
@@ -74,10 +74,10 @@ export const HeaderNavigation = () => {
       <Flex
         align="center"
         justify="space-between"
-        px={{ base: "8px", md: "16px" }}
-        py="8px"
+        px={{ base: "0.5rem", md: "1rem" }}
+        py="0.5rem"
       >
-        <Logo size="48px" />
+        <Logo size="3rem" />
         <Button variant="primary-outline" rounded="full">
           로그인
         </Button>
@@ -85,11 +85,11 @@ export const HeaderNavigation = () => {
       <Center as="nav" w="full" position="sticky" top="0">
         <Flex
           as="ul"
-          gap="24px"
+          gap="1.5rem"
           overflowX="auto"
           flexWrap="nowrap"
           w="full"
-          px="12px"
+          px="0.75rem"
           borderY="1px"
           borderColor="primary"
           bgColor="primary"
@@ -112,19 +112,19 @@ interface NavProps {
 
 const DesktopNav = ({ name, path, isExternalSite }: NavProps) => {
   return (
-    <WrapItem m={0} fontSize="18px" fontWeight="bold">
+    <WrapItem m="0px" fontSize="1.125rem" fontWeight="bold">
       {isExternalSite ? (
         <ExternalLink
           href={path}
           target="_blank"
           display="flex"
           alignItems="center"
-          columnGap={1}
+          columnGap="0.25rem"
           isExternal
           _hover={{ textDecoration: "none" }}
         >
-          <Text py={4}>{name}</Text>
-          <Icon as={BsBoxArrowUpRight} mb="1" boxSize="14px" />
+          <Text py="1rem">{name}</Text>
+          <Icon as={BsBoxArrowUpRight} mb="0.25rem" boxSize="0.875rem" />
         </ExternalLink>
       ) : (
         <NavLink to={path}>
@@ -133,7 +133,7 @@ const DesktopNav = ({ name, path, isExternalSite }: NavProps) => {
               fontWeight="bold"
               color={isActive ? "primary" : "gray.7"}
               position="relative"
-              py={4}
+              py="1rem"
               _before={
                 isActive
                   ? {
@@ -141,9 +141,9 @@ const DesktopNav = ({ name, path, isExternalSite }: NavProps) => {
                       position: "absolute",
                       display: "block",
                       w: "full",
-                      h: "4px",
-                      roundedTopLeft: "4px",
-                      roundedTopRight: "4px",
+                      h: "0.25rem",
+                      roundedTopLeft: "0.25rem",
+                      roundedTopRight: "0.25rem",
                       bgColor: "primary",
                       bottom: 0,
                     }
@@ -166,7 +166,7 @@ const Nav = ({ name, path, onClick }: NavProps) => {
         {({ isActive }) => (
           <Text
             position="relative"
-            py={3}
+            py="0.75rem"
             whiteSpace="nowrap"
             fontWeight="bold"
             color="primary-content"
@@ -179,9 +179,9 @@ const Nav = ({ name, path, onClick }: NavProps) => {
                     display: "block",
                     bottom: "1px",
                     w: "full",
-                    h: "4px",
-                    roundedTopLeft: "4px",
-                    roundedTopRight: "4px",
+                    h: "0.25rem",
+                    roundedTopLeft: "0.25rem",
+                    roundedTopRight: "0.25rem",
                     bgColor: "primary-content",
                     opacity: 0.6,
                   }

--- a/apps/se-board/src/components/HeaderNavigation.tsx
+++ b/apps/se-board/src/components/HeaderNavigation.tsx
@@ -16,7 +16,7 @@ import { Link, NavLink } from "react-router-dom";
 import { ReactComponent as SELogo } from "@/assets/images/se_logo.svg";
 import { semanticColors } from "@/styles";
 
-const DESKTOP_NAV_ITEMS: readonly NavProps[] = [
+const NAV_ITEMS: readonly NavProps[] = [
   { name: "공지", path: "notice" },
   { name: "자유", path: "free-board" },
   { name: "아카이브", path: "archive" },
@@ -24,6 +24,10 @@ const DESKTOP_NAV_ITEMS: readonly NavProps[] = [
   { name: "팀모집", path: "recruitment" },
   { name: "프로젝트실 예약", path: "projectroom-reservation" },
   { name: "서버 대여", path: "server-rental" },
+];
+
+const DESKTOP_NAV_ITEMS: readonly NavProps[] = [
+  ...NAV_ITEMS,
   {
     name: "학사",
     path: "https://cs.kumoh.ac.kr/cs/sub0601.do",
@@ -64,10 +68,46 @@ export const DesktopHeaderNavigation = () => {
   );
 };
 
+export const HeaderNavigation = () => {
+  return (
+    <>
+      <Flex
+        align="center"
+        justify="space-between"
+        px={{ base: "8px", md: "16px" }}
+        py="8px"
+      >
+        <Logo size="48px" />
+        <Button variant="primary-outline" rounded="full">
+          로그인
+        </Button>
+      </Flex>
+      <Center as="nav" w="full" position="sticky" top="0">
+        <Flex
+          as="ul"
+          gap="24px"
+          overflowX="auto"
+          flexWrap="nowrap"
+          w="full"
+          px="12px"
+          borderY="1px"
+          borderColor="primary"
+          bgColor="primary"
+        >
+          {NAV_ITEMS.map((item, i) => (
+            <Nav key={item.name} {...item} />
+          ))}
+        </Flex>
+      </Center>
+    </>
+  );
+};
+
 interface NavProps {
   name: string;
   path: string;
   isExternalSite?: boolean;
+  onClick?: () => void;
 }
 
 const DesktopNav = ({ name, path, isExternalSite }: NavProps) => {
@@ -119,11 +159,48 @@ const DesktopNav = ({ name, path, isExternalSite }: NavProps) => {
   );
 };
 
+const Nav = ({ name, path, onClick }: NavProps) => {
+  return (
+    <WrapItem m={0}>
+      <NavLink to={path}>
+        {({ isActive }) => (
+          <Text
+            position="relative"
+            py={3}
+            whiteSpace="nowrap"
+            fontWeight="bold"
+            color="primary-content"
+            opacity={isActive ? 1 : 0.5}
+            _before={
+              isActive
+                ? {
+                    content: `""`,
+                    position: "absolute",
+                    display: "block",
+                    bottom: "1px",
+                    w: "full",
+                    h: "4px",
+                    roundedTopLeft: "4px",
+                    roundedTopRight: "4px",
+                    bgColor: "primary-content",
+                    opacity: 0.6,
+                  }
+                : {}
+            }
+          >
+            {name}
+          </Text>
+        )}
+      </NavLink>
+    </WrapItem>
+  );
+};
+
 const Logo = ({ size }: { size: string }) => {
   return (
     <Link to="/">
       <Box boxSize={size}>
-        <SELogo width="full" height="full" fill={semanticColors.primary} />
+        <SELogo width="100%" height="100%" fill={semanticColors.primary} />
       </Box>
     </Link>
   );

--- a/apps/se-board/src/components/HeaderNavigation.tsx
+++ b/apps/se-board/src/components/HeaderNavigation.tsx
@@ -1,22 +1,34 @@
 import {
+  Avatar,
   Box,
   Button,
   ButtonGroup,
   Center,
+  Drawer,
+  DrawerBody,
+  DrawerCloseButton,
+  DrawerContent,
+  DrawerFooter,
+  DrawerHeader,
+  DrawerOverlay,
+  DrawerProps,
   Flex,
+  Hide,
   Icon,
   Link as ExternalLink,
+  Show,
   Text,
+  useDisclosure,
   Wrap,
   WrapItem,
 } from "@chakra-ui/react";
-import { BsBoxArrowUpRight } from "react-icons/bs";
+import { BsBoxArrowUpRight, BsList } from "react-icons/bs";
 import { Link, NavLink } from "react-router-dom";
 
 import { ReactComponent as SELogo } from "@/assets/images/se_logo.svg";
 import { semanticColors } from "@/styles";
 
-const NAV_ITEMS: readonly NavProps[] = [
+const NAV_ITEMS: readonly NavItemProps[] = [
   { name: "공지", path: "notice" },
   { name: "자유", path: "free-board" },
   { name: "아카이브", path: "archive" },
@@ -26,7 +38,7 @@ const NAV_ITEMS: readonly NavProps[] = [
   { name: "서버 대여", path: "server-rental" },
 ];
 
-const DESKTOP_NAV_ITEMS: readonly NavProps[] = [
+const DESKTOP_NAV_ITEMS: readonly NavItemProps[] = [
   ...NAV_ITEMS,
   {
     name: "학사",
@@ -41,6 +53,7 @@ const DESKTOP_NAV_ITEMS: readonly NavProps[] = [
 ] as const;
 
 export const DesktopHeaderNavigation = () => {
+  const { isOpen, onOpen, onClose } = useDisclosure();
   return (
     <Center as="header" shadow="base">
       <Flex
@@ -51,20 +64,63 @@ export const DesktopHeaderNavigation = () => {
         px="1rem"
       >
         <Logo size="3.5rem" />
-        <Box as="nav">
-          <Wrap spacingX="2rem" spacingY="0px">
-            {DESKTOP_NAV_ITEMS.map((item) => (
-              <DesktopNav key={item.name} {...item} />
-            ))}
-          </Wrap>
-        </Box>
-        <ButtonGroup>
-          <Button variant="primary-outline" rounded="full">
-            로그인
+        <Show above="lg">
+          <Box as="nav">
+            <Wrap spacingX="2rem" spacingY="0px">
+              {DESKTOP_NAV_ITEMS.map((item) => (
+                <DesktopNavItem key={item.name} {...item} />
+              ))}
+            </Wrap>
+          </Box>
+          <ButtonGroup>
+            <Button variant="primary-outline" rounded="full">
+              로그인
+            </Button>
+          </ButtonGroup>
+        </Show>
+        {/* tablet 사이즈에서 노출 desktop 사이즈에서 노출X */}
+        <Hide above="lg">
+          <Button onClick={onOpen} variant="ghost" p="0">
+            <Icon as={BsList} color="gray.7" boxSize="2rem" />
           </Button>
-        </ButtonGroup>
+          <DrawerNavigation isOpen={isOpen} onClose={onClose} />
+        </Hide>
       </Flex>
     </Center>
+  );
+};
+
+const DrawerNavigation = ({
+  onClose,
+  isOpen,
+  ...props
+}: Omit<DrawerProps, "children">) => {
+  return (
+    <Drawer isOpen={isOpen} onClose={onClose} {...props}>
+      <DrawerOverlay />
+      <DrawerContent>
+        <DrawerCloseButton />
+        {/* 로그인 했을 때 DrawerHeader 보여주기 */}
+        <DrawerHeader borderBottomWidth="1px">
+          <Flex alignItems="center" gap="1rem">
+            <Avatar />
+            <Text>박형준</Text>
+          </Flex>
+        </DrawerHeader>
+        <DrawerBody>
+          <Wrap>
+            {DESKTOP_NAV_ITEMS.map((item) => (
+              <DrawerNavItem {...item} onClick={onClose} />
+            ))}
+          </Wrap>
+        </DrawerBody>
+        <DrawerFooter borderTopWidth="1px">
+          <Button variant="primary" w="full">
+            로그인
+          </Button>
+        </DrawerFooter>
+      </DrawerContent>
+    </Drawer>
   );
 };
 
@@ -95,7 +151,7 @@ export const HeaderNavigation = () => {
           bgColor="primary"
         >
           {NAV_ITEMS.map((item, i) => (
-            <Nav key={item.name} {...item} />
+            <NavItem key={item.name} {...item} />
           ))}
         </Flex>
       </Center>
@@ -103,14 +159,14 @@ export const HeaderNavigation = () => {
   );
 };
 
-interface NavProps {
+interface NavItemProps {
   name: string;
   path: string;
   isExternalSite?: boolean;
   onClick?: () => void;
 }
 
-const DesktopNav = ({ name, path, isExternalSite }: NavProps) => {
+const DesktopNavItem = ({ name, path, isExternalSite }: NavItemProps) => {
   return (
     <WrapItem m="0px" fontSize="1.125rem" fontWeight="bold">
       {isExternalSite ? (
@@ -159,7 +215,65 @@ const DesktopNav = ({ name, path, isExternalSite }: NavProps) => {
   );
 };
 
-const Nav = ({ name, path, onClick }: NavProps) => {
+const DrawerNavItem = ({
+  name,
+  path,
+  isExternalSite,
+  onClick,
+}: NavItemProps) => {
+  return (
+    <WrapItem
+      onClick={onClick}
+      w="full"
+      m="0px"
+      fontSize="1.125rem"
+      fontWeight="bold"
+    >
+      {isExternalSite ? (
+        <ExternalLink
+          isExternal
+          href={path}
+          target="_blank"
+          w="full"
+          _hover={{ textDecoration: "none" }}
+        >
+          <Box
+            display="flex"
+            alignItems="center"
+            columnGap="0.25rem"
+            w="full"
+            p="1rem"
+            rounded="lg"
+            transition="background-color 0.2s"
+            _hover={{ bgColor: "gray.0" }}
+          >
+            <Text>{name}</Text>
+            <Icon as={BsBoxArrowUpRight} mb="0.25rem" boxSize="0.875rem" />
+          </Box>
+        </ExternalLink>
+      ) : (
+        <NavLink to={path} style={{ width: "100%" }}>
+          {({ isActive }) => (
+            <Box
+              w="full"
+              p="1rem"
+              bgColor={isActive ? "gray.1" : "transparent"}
+              rounded="lg"
+              transition="background-color 0.2s"
+              _hover={{ bgColor: "gray.0" }}
+            >
+              <Text fontWeight="bold" color={isActive ? "primary" : "gray.7"}>
+                {name}
+              </Text>
+            </Box>
+          )}
+        </NavLink>
+      )}
+    </WrapItem>
+  );
+};
+
+const NavItem = ({ name, path }: NavItemProps) => {
   return (
     <WrapItem m={0}>
       <NavLink to={path}>

--- a/apps/se-board/src/components/HeaderNavigation.tsx
+++ b/apps/se-board/src/components/HeaderNavigation.tsx
@@ -1,0 +1,130 @@
+import {
+  Box,
+  Button,
+  ButtonGroup,
+  Center,
+  Flex,
+  Icon,
+  Link as ExternalLink,
+  Text,
+  Wrap,
+  WrapItem,
+} from "@chakra-ui/react";
+import { BsBoxArrowUpRight } from "react-icons/bs";
+import { Link, NavLink } from "react-router-dom";
+
+import { ReactComponent as SELogo } from "@/assets/images/se_logo.svg";
+import { semanticColors } from "@/styles";
+
+const DESKTOP_NAV_ITEMS: readonly NavProps[] = [
+  { name: "공지", path: "notice" },
+  { name: "자유", path: "free-board" },
+  { name: "아카이브", path: "archive" },
+  { name: "지도교수 상담", path: "consulting" },
+  { name: "팀모집", path: "recruitment" },
+  { name: "프로젝트실 예약", path: "projectroom-reservation" },
+  { name: "서버 대여", path: "server-rental" },
+  {
+    name: "학사",
+    path: "https://cs.kumoh.ac.kr/cs/sub0601.do",
+    isExternalSite: true,
+  },
+  {
+    name: "채용",
+    path: "https://cs.kumoh.ac.kr/cs/sub0602.do",
+    isExternalSite: true,
+  },
+] as const;
+
+export const DesktopHeaderNavigation = () => {
+  return (
+    <Center as="header" shadow="base">
+      <Flex
+        maxW="container.xl"
+        w="full"
+        align="center"
+        justify="space-between"
+        px="16px"
+      >
+        <Logo size="56px" />
+        <Box as="nav">
+          <Wrap spacingX="32px" spacingY="0px">
+            {DESKTOP_NAV_ITEMS.map((item) => (
+              <DesktopNav key={item.name} {...item} />
+            ))}
+          </Wrap>
+        </Box>
+        <ButtonGroup>
+          <Button variant="primary-outline" rounded="full">
+            로그인
+          </Button>
+        </ButtonGroup>
+      </Flex>
+    </Center>
+  );
+};
+
+interface NavProps {
+  name: string;
+  path: string;
+  isExternalSite?: boolean;
+}
+
+const DesktopNav = ({ name, path, isExternalSite }: NavProps) => {
+  return (
+    <WrapItem m={0} fontSize="18px" fontWeight="bold">
+      {isExternalSite ? (
+        <ExternalLink
+          href={path}
+          target="_blank"
+          display="flex"
+          alignItems="center"
+          columnGap={1}
+          isExternal
+          _hover={{ textDecoration: "none" }}
+        >
+          <Text py={4}>{name}</Text>
+          <Icon as={BsBoxArrowUpRight} mb="1" boxSize="14px" />
+        </ExternalLink>
+      ) : (
+        <NavLink to={path}>
+          {({ isActive }) => (
+            <Text
+              fontWeight="bold"
+              color={isActive ? "primary" : "gray.7"}
+              position="relative"
+              py={4}
+              _before={
+                isActive
+                  ? {
+                      content: `""`,
+                      position: "absolute",
+                      display: "block",
+                      w: "full",
+                      h: "4px",
+                      roundedTopLeft: "4px",
+                      roundedTopRight: "4px",
+                      bgColor: "primary",
+                      bottom: 0,
+                    }
+                  : {}
+              }
+            >
+              {name}
+            </Text>
+          )}
+        </NavLink>
+      )}
+    </WrapItem>
+  );
+};
+
+const Logo = ({ size }: { size: string }) => {
+  return (
+    <Link to="/">
+      <Box boxSize={size}>
+        <SELogo width="full" height="full" fill={semanticColors.primary} />
+      </Box>
+    </Link>
+  );
+};

--- a/apps/se-board/src/components/index.tsx
+++ b/apps/se-board/src/components/index.tsx
@@ -1,0 +1,1 @@
+export * from "./HeaderNavigation";

--- a/apps/se-board/src/components/layouts/MainLayout.tsx
+++ b/apps/se-board/src/components/layouts/MainLayout.tsx
@@ -1,7 +1,7 @@
-import { Show } from "@chakra-ui/react";
+import { Hide, Show } from "@chakra-ui/react";
 import { Outlet } from "react-router-dom";
 
-import { DesktopHeaderNavigation } from "@/components/HeaderNavigation";
+import { DesktopHeaderNavigation, HeaderNavigation } from "@/components";
 
 export const MainLayout = () => {
   return (
@@ -9,7 +9,9 @@ export const MainLayout = () => {
       <Show above="lg">
         <DesktopHeaderNavigation />
       </Show>
-
+      <Hide above="lg">
+        <HeaderNavigation />
+      </Hide>
       <Outlet />
     </>
   );

--- a/apps/se-board/src/components/layouts/MainLayout.tsx
+++ b/apps/se-board/src/components/layouts/MainLayout.tsx
@@ -1,0 +1,16 @@
+import { Show } from "@chakra-ui/react";
+import { Outlet } from "react-router-dom";
+
+import { DesktopHeaderNavigation } from "@/components/HeaderNavigation";
+
+export const MainLayout = () => {
+  return (
+    <>
+      <Show above="lg">
+        <DesktopHeaderNavigation />
+      </Show>
+
+      <Outlet />
+    </>
+  );
+};

--- a/apps/se-board/src/components/layouts/MainLayout.tsx
+++ b/apps/se-board/src/components/layouts/MainLayout.tsx
@@ -6,10 +6,10 @@ import { DesktopHeaderNavigation, HeaderNavigation } from "@/components";
 export const MainLayout = () => {
   return (
     <>
-      <Show above="lg">
+      <Show above="md">
         <DesktopHeaderNavigation />
       </Show>
-      <Hide above="lg">
+      <Hide above="md">
         <HeaderNavigation />
       </Hide>
       <Outlet />

--- a/apps/se-board/src/components/layouts/index.tsx
+++ b/apps/se-board/src/components/layouts/index.tsx
@@ -1,0 +1,1 @@
+export * from "./MainLayout";


### PR DESCRIPTION
## 개요

notion : https://www.notion.so/3ddf9148fae949dd823a40970a7f83ab?pvs=4
<br>
<br>

## 작업내용
데스크탑, 모바일 디자인 차이가 많아서 분리하여 만듬
- 데스크탑용 헤더네비게이션
- 모바일용 헤더네비게이션
- 페이지별 라우팅
- 학사, 채용 사이트는 새로운 창으로 open




## 참고 내용
전환되는 기준을 lg(992px)로  992px이 꽤 넓어서 md(768px)로 변경하는 것도 괜찮을 것 같다 
