### PR TITLE
mobile header & post rendering issue

### DIFF
--- a/apps/se-board/src/pages/NoticeWrite.tsx
+++ b/apps/se-board/src/pages/NoticeWrite.tsx
@@ -61,7 +61,7 @@ export const NoticeWrite = () => {
       isModified.current = true;
     }
 
-    return mobileHeaderOpen();
+    return () => mobileHeaderOpen();
   }, []);
 
   useEffect(() => {

--- a/apps/se-board/src/pages/PostPage.tsx
+++ b/apps/se-board/src/pages/PostPage.tsx
@@ -9,9 +9,6 @@ import {
   Content,
   DesktopHeader,
   Header,
-  SkeletonDetailPostContent,
-  SkeletonDetailPostDesktopHeader,
-  SkeletonDetailPostHeader,
 } from "@/components/detailPost";
 import { useGetPostQuery, useSecretPostMutation } from "@/react-query/hooks";
 import { useMobileHeaderState } from "@/store/mobileHeaderState";
@@ -20,13 +17,14 @@ import { convertPostInfo } from "@/utils/postUtils";
 
 import { PageNotFound } from "./PageNotFound";
 import { PWInput } from "./SecretPostPWInput";
+import { SkeletonPostPage } from "./SkeletonPostPage";
 
 export const PostPage = () => {
   const { postId } = useParams();
 
   const enabledRef = useRef<boolean>(true);
 
-  const { data, isLoading, isError, error } = useGetPostQuery(
+  const { data, isFetching, isError, error } = useGetPostQuery(
     postId,
     enabledRef.current
   );
@@ -94,32 +92,24 @@ export const PostPage = () => {
     <Box maxW="984px" w="100%">
       <Show above="md">
         <Box pt="0rem">
-          {isLoading || secretIsLoading ? (
-            <SkeletonDetailPostDesktopHeader />
-          ) : (
-            <DesktopHeader HeadingInfo={postHeaderInfo} />
-          )}
+          <DesktopHeader HeadingInfo={postHeaderInfo} />
         </Box>
       </Show>
       <Hide above="md">
-        {isLoading || secretIsLoading ? (
-          <SkeletonDetailPostHeader />
-        ) : (
-          <Header HeadingInfo={postHeaderInfo} />
-        )}
+        <Header HeadingInfo={postHeaderInfo} />
       </Hide>
       <AttachmentFile files={attachemntFileData || []} />
-      {isLoading || secretIsLoading ? (
-        <SkeletonDetailPostContent />
-      ) : (
-        <Content contents={content || "<p></p>"} />
-      )}
+
+      <Content contents={content || "<p></p>"} />
+
       <CommentSection
         postId={postId}
         isPostRequestError={!!postHeaderInfo}
         password={password || undefined}
       />
     </Box>
+  ) : isFetching || secretIsLoading ? (
+    <SkeletonPostPage />
   ) : (
     <PageNotFound />
   );

--- a/apps/se-board/src/pages/PostPage.tsx
+++ b/apps/se-board/src/pages/PostPage.tsx
@@ -46,7 +46,7 @@ export const PostPage = () => {
   useEffect(() => {
     mobileHeaderClose();
 
-    return mobileHeaderOpen();
+    return () => mobileHeaderOpen();
   }, []);
 
   useEffect(() => {

--- a/apps/se-board/src/pages/SkeletonPostPage.tsx
+++ b/apps/se-board/src/pages/SkeletonPostPage.tsx
@@ -1,0 +1,23 @@
+import { Box, Hide, Show } from "@chakra-ui/react";
+
+import {
+  SkeletonDetailPostContent,
+  SkeletonDetailPostDesktopHeader,
+  SkeletonDetailPostHeader,
+} from "@/components/detailPost";
+
+export const SkeletonPostPage = () => {
+  return (
+    <Box maxW="984px" w="100%">
+      <Show above="md">
+        <Box pt="0rem">
+          <SkeletonDetailPostDesktopHeader />
+        </Box>
+      </Show>
+      <Hide above="md">
+        <SkeletonDetailPostHeader />
+      </Hide>
+      <SkeletonDetailPostContent />
+    </Box>
+  );
+};

--- a/apps/se-board/src/store/mobileHeaderState.ts
+++ b/apps/se-board/src/store/mobileHeaderState.ts
@@ -8,7 +8,7 @@ export const mobileHeaderState = atom({
 export const useMobileHeaderState = () => {
   const [value, setValue] = useRecoilState(mobileHeaderState);
   return {
-    mobileHeaderOpen: () => setValue(false),
-    mobileHeaderClose: () => setValue(true),
+    mobileHeaderOpen: () => setValue(true),
+    mobileHeaderClose: () => setValue(false),
   };
 };


### PR DESCRIPTION
## 개요

notion : "노션 테스크 주소 넣기"
<br>
<br>

## 작업내용

- 모바일 UI에서 게시글 상세 조회 페이지와 글 작성 페이지 뒤로가기 시 헤더 사라지는 이슈
- 게시글 상세 조회 시 데이터 조회 과정에서 PageNotFound 뜨는 이슈
<br>
<br>

## 참고 내용

"코드 리뷰시 참고할 내용"
