### PR TITLE
[Test] Add dateUtils.test, commentUtil.test

### DIFF
--- a/apps/se-board/src/@types/Comment.d.ts
+++ b/apps/se-board/src/@types/Comment.d.ts
@@ -20,7 +20,7 @@ declare module "@types" {
   }
 
   interface SubCommentContent extends CommentContent {
-    tag: number;
+    tag?: number;
   }
 
   interface CommentsData {

--- a/apps/se-board/src/@types/Comment.d.ts
+++ b/apps/se-board/src/@types/Comment.d.ts
@@ -20,7 +20,7 @@ declare module "@types" {
   }
 
   interface SubCommentContent extends CommentContent {
-    tag?: number;
+    tag: number | null;
   }
 
   interface CommentsData {

--- a/apps/se-board/src/tests/unit/utils/commonUtil.test.ts
+++ b/apps/se-board/src/tests/unit/utils/commonUtil.test.ts
@@ -3,6 +3,7 @@ import { SubCommentContent } from "@types";
 import { getTagName } from "@/utils/commentUtils";
 
 let subComment: SubCommentContent = {
+  tag: null,
   commentId: 90,
   author: {
     userId: "",

--- a/apps/se-board/src/tests/unit/utils/commonUtil.test.ts
+++ b/apps/se-board/src/tests/unit/utils/commonUtil.test.ts
@@ -1,0 +1,67 @@
+import { SubCommentContent } from "@types";
+
+import { getTagName } from "@/utils/commentUtils";
+
+let subComment: SubCommentContent = {
+  commentId: 90,
+  author: {
+    userId: "",
+    name: "string",
+  },
+  createdAt: "string",
+  modifiedAt: "string",
+  contents: "string",
+  isEditable: true,
+  isActive: true,
+  isReadOnlyAuthor: true,
+};
+
+const superComment = {
+  authorName: "superComment",
+  commentId: 1,
+};
+
+const subComments: SubCommentContent[] = [];
+
+describe("commentUtil test", () => {
+  it("When comment.tag is null, should return undefined", () => {
+    expect(getTagName(subComment, superComment, subComments)).toBeUndefined();
+  });
+
+  it("When subComment's tag is the same with superComment's commentId, it should return superComment's authorName", () => {
+    const sameCommentId = 1;
+    const testSubComment: SubCommentContent = {
+      ...subComment,
+      tag: sameCommentId,
+    };
+    const testSuperComment = { ...superComment, commentId: sameCommentId };
+    expect(getTagName(testSubComment, testSuperComment, subComments)).toBe(
+      "superComment"
+    );
+  });
+
+  it("When subComment's tag is different with superComment's commentId, it should return subComment's authorName where comment's tag is the same with subComment's commentId", () => {
+    const sameCommentId = 1;
+    const differentSuperComment = { ...superComment, commentId: 100 };
+    const testSubComment: SubCommentContent = {
+      ...subComment,
+      tag: sameCommentId,
+      author: {
+        userId: "test",
+        name: "철수",
+      },
+    };
+    const sameSubComment: SubCommentContent = {
+      ...subComment,
+      commentId: sameCommentId,
+      author: {
+        userId: "userId",
+        name: "홍길동",
+      },
+    };
+    const testSubComments: SubCommentContent[] = [sameSubComment];
+    expect(
+      getTagName(testSubComment, differentSuperComment, testSubComments)
+    ).toBe("홍길동");
+  });
+});

--- a/apps/se-board/src/tests/unit/utils/dateUtils.test.ts
+++ b/apps/se-board/src/tests/unit/utils/dateUtils.test.ts
@@ -1,0 +1,41 @@
+import {
+  isModifiedContent,
+  isSameDateTime,
+  toYYMMDD_DOT,
+  toYYYYMMDDHHhh,
+  toYYYYMMDDHHhhss,
+} from "@/utils/dateUtils";
+
+describe("dateUtils test", () => {
+  it("change date format to YY.MM.DD", () => {
+    expect(toYYMMDD_DOT("2024-08-04")).toBe("24.08.04");
+  });
+
+  it("same date should return true", () => {
+    expect(isSameDateTime("2024-08-04", "2024-08-04")).toBeTruthy();
+  });
+
+  it("different date should return false", () => {
+    expect(isSameDateTime("2024-08-04", "2024-10-12")).toBeFalsy();
+  });
+
+  it("change date format to YYYY.MM.DD HH:mm:ss", () => {
+    expect(toYYYYMMDDHHhhss("2024-08-04 18:33:00")).toBe("2024.08.04 18:33:00");
+  });
+
+  it("change date format to YYYY.MM.DD HH:mm", () => {
+    expect(toYYYYMMDDHHhh("2024-08-04 18:33:00")).toBe("2024.08.04 18:33");
+  });
+
+  it("modified content should return true", () => {
+    const createdDate = "2024-08-04 18:33:00";
+    const modifedDate = "2024-08-05 18:00:00";
+    expect(isModifiedContent(createdDate, modifedDate)).toBeTruthy();
+  });
+
+  it("unmodified content should return false", () => {
+    const createdDate = "2024-08-04 18:33:00";
+    const modifiedDate = "2024-08-04 18:33:00";
+    expect(isModifiedContent(createdDate, modifiedDate)).toBeFalsy();
+  });
+});


### PR DESCRIPTION
## 개요

notion : https://www.notion.so/FE-dateUtils-commentUtil-c0175f8dac8841e98fa996db1d0797c6?pvs=4
<br>
<br>

## 작업내용

Test: 
add dateUtils.test
add commentUtil.test

Fix: SubCommentContent 인터페이스의 tag 속성을 옵션 속성으로 변경
<br>
<br>

## 참고 내용

https://github.com/kit-SE-Project/SE-FE.git